### PR TITLE
fix italic in wrong place in legalcode

### DIFF
--- a/docroot/includes/legalcode.css
+++ b/docroot/includes/legalcode.css
@@ -200,11 +200,9 @@ h3 {
     padding: 20px;
 }
 
-#deed-main-content .shaded :first-child { margin-top: 0; }
+#deed-main-content .shaded :first-child { margin-top: 0; font-style: italic; }
 
 #deed-main-content .shaded :last-child { margin-bottom: 0; }
-
-#deed-main-content div:nth-child(2) { font-style: italic; }
 
 #deed-main-content .usage-considerations {
     background-color: #fff;


### PR DESCRIPTION
Fixes creativecommons/creativecommons.org#1028

**Description**
there was a style with a wide range selector in legalcode.css 
```
#deed-main-content div:nth-child(2) { font-style: italic; }
```
this was meant to be used to the first div in legal code but also affects the subsections mentioned in creativecommons/creativecommons.org#1028. I added the style in a more specific selector to avoid this issue


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
